### PR TITLE
Build simple ping-pong implementation

### DIFF
--- a/client.py
+++ b/client.py
@@ -17,6 +17,7 @@ def print_help():
     help_text = f"""
 Available commands:
 /help                             - Show this help message.
+/ping                             - Send a ping request and shows current IP and ports.
 /upload <file_path>               - Upload a file to the server.
 /download <file_name>             - Download a file from the server.
 /list                             - List all files on the server.
@@ -179,6 +180,22 @@ def list_files(server_host: str, server_port: int):
         logging.error(f"Error listing files: {e}")
 
 
+def ping(server_host: str, server_port: int):
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(5)
+            sock.connect((server_host, server_port))
+            # Send a simple PING request
+            request = "PING\r\n\r\n"
+            sock.sendall(request.encode('utf-8'))
+            response = sock.recv(4096).decode('utf-8').strip()
+            print(f"Server response: {response}")
+    except socket.timeout:
+        logging.error("Ping request timed out.")
+    except Exception as e:
+        logging.error(f"Error during ping: {e}")
+
+
 def main():
     global SERVER_HOST, SERVER_PORT
 
@@ -197,6 +214,15 @@ def main():
 
         if user_input.startswith("/help"):
             print_help()
+        # Handle '/ping' command
+        elif user_input.startswith("/ping"):
+            try:
+                ping(SERVER_HOST, SERVER_PORT)
+            except Exception as e:
+                logging.error(f"Ping command failed: {e}")
+            continue
+
+
         elif user_input.startswith("/upload"):
             parts = user_input.split(maxsplit=1)
             if len(parts) < 2:

--- a/server.py
+++ b/server.py
@@ -125,6 +125,14 @@ def handle_client(conn: socket.socket, address: tuple):
             response = "\n".join(files) + "\r\n"
             conn.sendall(response.encode('utf-8'))
             logging.info(f"Sent file list to {address}")
+
+        elif request_line.upper() == "PING":
+            message = (f"Pong! Connected to server.\n"
+                       f"Your IP and port: {address}\n"
+                       f"Server IP and port: {conn.getsockname()} \n")
+            logging.info(f"Have been pinged, will pong to {address}")
+            # Send pong message response to client
+            conn.sendall(message.encode('utf-8'))
         else:
             logging.error(f"Unknown request method {request_line} from {address}")
 


### PR DESCRIPTION
De server- en client-Python-code is geüpdatet met de implementatie van Alex als voorbeeld.  
Getest en bevestigd, het is een eenvoudige ping-pong functionaliteit.  
Handig voor testen, omdat het de verbinding verifieert en zowel het waargenomen IP- en poortnummer van de client als het IP- en poortnummer van de server in één bericht terugstuurt.

Dit was geen FE/eis maar meer een oefening en handige extra functionaliteit om te hebben. Misschien moeten we hier wel een (extra) eis van maken?
