### PR TITLE
Fe7 clean up partials 2

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ import re
 import time
 import websockets
 import json
+import threading
 import os
 import logging
 from watchdog.observers import Observer
@@ -14,7 +15,11 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(me
 
 # Directory where files are stored
 FILE_STORAGE_DIR = "./uploads"
+# .partial extension used during upload transaction
 PARTIAL_SUFFIX = ".partial"
+# Timeout for `.part` files in seconds (10 minutes)
+PARTIAL_FILE_TIMEOUT = 10 * 60
+
 os.makedirs(FILE_STORAGE_DIR, exist_ok=True)
 
 # Common temporary file prefixes & extensions to ignore
@@ -23,6 +28,34 @@ IGNORED_SUFFIXES = (".swp", ".tmp", ".lock", ".part", ".partial", ".crdownload",
 
 # Set to keep track of connected clients
 connected_clients = set()
+
+# _______________________ FE7 ____________________________
+# Waits async for the defined timeout to remove any stale .part files.
+def clean_stale_partial_files():
+    # wait for the timeout period plus one extra second
+    time.sleep(PARTIAL_FILE_TIMEOUT + 1)
+    current_time = time.time()
+    try:
+        # Go through each file in the directory
+        for filename in os.listdir(FILE_STORAGE_DIR):
+            if filename.endswith(PARTIAL_SUFFIX):
+                file_path = os.path.join(FILE_STORAGE_DIR, filename)
+                last_modified_time = os.path.getmtime(file_path)
+                if current_time - last_modified_time > PARTIAL_FILE_TIMEOUT:
+                    logging.info(f"Deleting stale {PARTIAL_SUFFIX} file: {file_path}")
+                    os.remove(file_path)
+    except (FileNotFoundError, PermissionError) as e:
+        logging.error(f"No '.partial' files detected during cleanup, closing thread: {e}")
+
+# Starts a cleanup thread if any .part file exists.
+def start_stale_file_cleanup():
+    if any(filename.endswith(PARTIAL_SUFFIX) for filename in os.listdir(FILE_STORAGE_DIR)):
+        logging.info("Starting stale file cleanup thread.")
+        cleanup_thread = threading.Thread(target=clean_stale_partial_files, daemon=True)
+        cleanup_thread.start()
+    else:
+        logging.info("No .part files found. Cleanup thread not started.")
+
 
 
 # ----------------------- Helper Methods -----------------------
@@ -242,6 +275,9 @@ async def receive_file(websocket, filename):
     except Exception as e:
         logging.error(f"Error receiving file {filename}: {e}")
         await websocket.send(json.dumps({"status": "ERROR", "message": "File upload failed"}))
+    finally:
+        # Check if cleanup of .partial files is needed
+        start_stale_file_cleanup()
 
 
 async def send_file(websocket, filename):
@@ -369,6 +405,7 @@ if __name__ == "__main__":
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     observer = start_watchdog_observer(loop)
+    start_stale_file_cleanup()
 
 
     async def main():

--- a/server.py
+++ b/server.py
@@ -18,11 +18,77 @@ os.makedirs(FILE_STORAGE_DIR, exist_ok=True)
 
 # Common temporary file prefixes & extensions to ignore
 IGNORED_PREFIXES = ("~$", ".")
-IGNORED_SUFFIXES = (".swp", ".tmp", ".lock", ".part")
+IGNORED_SUFFIXES = (".swp", ".tmp", ".lock", ".part", ".crdownload", ".download", ".bak", ".old", ".temp", ".sha256")
 
 # Set to keep track of connected clients
 connected_clients = set()
 
+
+# ----------------------- Helper Methods -----------------------
+
+def compute_hash(file_path):
+    hasher = hashlib.sha256()
+    try:
+        with open(file_path, 'rb') as f:
+            while chunk := f.read(4096):
+                hasher.update(chunk)
+    except Exception as e:
+        logging.error(f"Error computing hash for {file_path}: {e}")
+        return None
+    return hasher.hexdigest()
+
+
+def get_hash_file_path(file_path):
+    return file_path + ".sha256"
+
+
+def get_cached_hash(file_path):
+    """
+    Returns the cached SHA256 hash from the .sha256 file if available and up-to-date.
+    If not, computes the hash, saves it, and returns the new value.
+    """
+    hash_file = get_hash_file_path(file_path)
+
+    # Check if the .sha256 file exists and is up-to-date.
+    if os.path.exists(hash_file):
+        # We can store the file modification time inside the .sha256 file if needed.
+        #  we assume that if the .sha256 exists, it is valid.
+        try:
+            with open(hash_file, "r") as hf:
+                cached = hf.read().strip()
+            return cached
+        except Exception as e:
+            logging.error(f"Error reading cached hash for {file_path}: {e}")
+
+    # If no valid cache exists, compute and store the hash.
+    new_hash = compute_hash(file_path)
+    if new_hash:
+        try:
+            with open(hash_file, "w") as hf:
+                hf.write(new_hash)
+            logging.info(f"Cached new hash for {file_path}.")
+        except Exception as e:
+            logging.error(f"Error writing cached hash for {file_path}: {e}")
+    return new_hash
+
+
+def invalidate_cached_hash(file_path):
+    """Removes the cached hash file if it exists."""
+    hash_file = get_hash_file_path(file_path)
+    if os.path.exists(hash_file):
+        try:
+            os.remove(hash_file)
+            logging.info(f"Invalidated cached hash for {file_path}.")
+        except Exception as e:
+            logging.error(f"Error removing cached hash for {file_path}: {e}")
+
+
+def sanitize_filename(filename: str) -> str:
+    filename = os.path.basename(filename)
+    return re.sub(r'[^a-zA-Z0-9_.-]', '_', filename)
+
+
+# ----------------------- WebSocket Handlers -----------------------
 
 async def websocket_handler(websocket: websockets.ServerConnection) -> None:
     """Handles WebSocket connections and processes commands and event messages."""
@@ -56,13 +122,13 @@ async def websocket_handler(websocket: websockets.ServerConnection) -> None:
 async def handle_client_notification(data, websocket):
     """
     Processes a notification message sent from a client.
-    Checks both timestamps and file sizes to determine if an upload is needed.
+    Checks timestamps, file sizes, and uses the cached SHA256 hash for comparison.
     """
-
     event_type = data.get("event")
     filename = data.get("filename")
     client_timestamp = data.get("timestamp")
-    client_file_size = int(data.get("size", 0))  # Include file size in client notifications
+    client_file_size = int(data.get("size", 0))
+    client_hash = data.get("hash")  # Client-provided hash
     file_path = os.path.join(FILE_STORAGE_DIR, filename)
 
     # Ignore temporary files
@@ -71,7 +137,8 @@ async def handle_client_notification(data, websocket):
         return
 
     logging.info(
-        f"Received client notification: File '{filename}' {event_type} at {client_timestamp} with size {client_file_size} bytes")
+        f"Received client notification: File '{filename}' {event_type} at {client_timestamp} with size {client_file_size} bytes"
+    )
 
     if event_type in ["created", "modified"]:
         await asyncio.sleep(1)  # Give time for saving before checking
@@ -86,8 +153,16 @@ async def handle_client_notification(data, websocket):
             logging.info(f"Ignoring file '{filename}' because its size is 0 bytes.")
             return
 
-        # Upload file if the client's version is newer OR the file size is different
+        # If metadata indicates a change, use the cached hash to verify file contents
         if client_timestamp > server_timestamp or client_file_size != server_file_size:
+            if client_hash:
+                server_hash = get_cached_hash(file_path) if os.path.exists(file_path) else None
+                if server_hash and server_hash == client_hash:
+                    logging.info(f"File '{filename}' hash matches; no upload required.")
+                    return  # No upload needed because content is the same
+                else:
+                    logging.info(f"Hash mismatch (client: {client_hash}, server: {server_hash}).")
+            # Request upload if no hash provided or if hashes differ
             request = json.dumps({"command": "REQUEST_UPLOAD", "filename": filename})
             await websocket.send(request)
             logging.info(f"Requested upload for file '{filename}' from client.")
@@ -97,6 +172,7 @@ async def handle_client_notification(data, websocket):
     elif event_type == "deleted":
         if os.path.exists(file_path):
             os.remove(file_path)
+            invalidate_cached_hash(file_path)
             logging.info(f"File '{filename}' deleted on server as per client notification.")
             await notify_clients("deleted", filename)
         else:
@@ -107,7 +183,7 @@ async def notify_clients(event_type, filename):
     """Sends a notification to all connected clients, including the file's last modified timestamp."""
     if not connected_clients:
         logging.warning(f"[NOTIFY] No connected clients to notify about '{filename}' {event_type}.")
-        return  # Exit early if there are no clients
+        return
 
     file_path = os.path.join(FILE_STORAGE_DIR, filename)
     timestamp = int(os.path.getmtime(file_path)) if os.path.exists(file_path) else int(time.time())
@@ -121,94 +197,15 @@ async def notify_clients(event_type, filename):
     })
 
     logging.info(
-        f"[NOTIFYING {len(connected_clients)} CLIENTS] File '{filename}' {event_type} at {timestamp} (size: {file_size} bytes)")
+        f"[NOTIFYING {len(connected_clients)} CLIENTS] File '{filename}' {event_type} at {timestamp} (size: {file_size} bytes)"
+    )
     await asyncio.gather(*(client.send(message) for client in connected_clients))
 
 
-def should_ignore(filename):
-    """Checks if the file should be ignored based on its name."""
-    return filename.startswith(IGNORED_PREFIXES) or filename.endswith(IGNORED_SUFFIXES)
-
-
-class AsyncSyncEventHandler(FileSystemEventHandler):
-    """
-    Monitors file system changes and debounces events before notifying clients.
-    If multiple events for the same file occur within a short interval, only the last event is processed.
-    """
-    def __init__(self, loop: asyncio.AbstractEventLoop, debounce_interval: float = 0.3):
-        super().__init__()
-        self.loop = loop
-        self.debounce_interval = debounce_interval
-        self.debounce_interval = debounce_interval
-        self.debounce_tasks: dict[str, asyncio.Task] = {}
-        self.latest_events: dict[str, str] = {}
-
-    def enqueue_event(self, event_type: str, filename: str) -> None:
-        if should_ignore(filename):
-            return
-        logging.info(f"[WATCHDOG] File {event_type}: {filename}")
-        # Update the latest event for this file.
-        self.latest_events[filename] = event_type
-
-        # Cancel any previously scheduled task for this file.
-        if filename in self.debounce_tasks:
-            self.debounce_tasks[filename].cancel()
-
-        # Schedule a new task that waits for the debounce interval before notifying.
-        self.debounce_tasks[filename] = self.loop.create_task(self._debounced_notify(filename))
-
-    async def _debounced_notify(self, filename: str) -> None:
-        try:
-            await asyncio.sleep(self.debounce_interval)
-            event_type = self.latest_events.get(filename)
-            # Clean up the stored event and task.
-            self.latest_events.pop(filename, None)
-            self.debounce_tasks.pop(filename, None)
-            await notify_clients(event_type, filename)
-        except asyncio.CancelledError:
-            # Task was cancelled because a new event arrived for the same file.
-            pass
-        except Exception as e:
-            logging.error(f"Error in debounced notify for '{filename}': {e}", exc_info=True)
-
-    def on_created(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            self.enqueue_event("created", os.path.basename(event.src_path))
-
-    def on_modified(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            self.enqueue_event("modified", os.path.basename(event.src_path))
-
-    def on_deleted(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            self.enqueue_event("deleted", os.path.basename(event.src_path))
-
-    def on_moved(self, event: FileSystemEvent) -> None:
-        if not event.is_directory:
-            # Treat a move as a deletion of the source file and creation of the destination file.
-            self.enqueue_event("deleted", os.path.basename(event.src_path))
-            self.enqueue_event("created", os.path.basename(event.dest_path))
-
-
-def compute_hash(file_path):
-    hasher = hashlib.sha256()
-    try:
-        with open(file_path, 'rb') as f:
-            while chunk := f.read(4096):
-                hasher.update(chunk)
-    except Exception as e:
-        logging.error(f"Error computing hash for {file_path}: {e}")
-        return None
-    return hasher.hexdigest()
-
-
-def sanitize_filename(filename: str) -> str:
-    filename = os.path.basename(filename)
-    return re.sub(r'[^a-zA-Z0-9_.-]', '_', filename)
-
+# ----------------------- File Reception and Transfer -----------------------
 
 async def receive_file(websocket, filename):
-    """Receives a file from the client and saves it on the server."""
+    """Receives a file from the client, saves it, and caches its SHA256 hash."""
     file_path = os.path.join(FILE_STORAGE_DIR, filename)
     logging.info(f"Receiving file: {filename}")
 
@@ -219,6 +216,16 @@ async def receive_file(websocket, filename):
                 if chunk == "EOF":
                     break
                 f.write(chunk)
+
+        # After file upload, compute and cache the hash.
+        new_hash = compute_hash(file_path)
+        if new_hash:
+            try:
+                with open(get_hash_file_path(file_path), "w") as hf:
+                    hf.write(new_hash)
+                logging.info(f"Cached SHA256 hash for '{filename}'.")
+            except Exception as e:
+                logging.error(f"Error caching hash for {filename}: {e}")
 
         logging.info(f"File {filename} uploaded successfully!")
         await notify_clients("created", filename)
@@ -253,11 +260,9 @@ async def delete_file(websocket, filename):
 
     if os.path.exists(file_path):
         os.remove(file_path)
+        invalidate_cached_hash(file_path)
         logging.info(f"File '{filename}' deleted as per request.")
-
-        # Notify all clients about the deletion
         await notify_clients("deleted", filename)
-
         await websocket.send(json.dumps({"status": "OK", "message": f"File '{filename}' deleted"}))
     else:
         logging.warning(f"File '{filename}' not found for deletion.")
@@ -265,11 +270,74 @@ async def delete_file(websocket, filename):
 
 
 async def list_files(websocket):
-    """Sends a list of available files to the client."""
-    files = [f for f in os.listdir(FILE_STORAGE_DIR) if os.path.isfile(os.path.join(FILE_STORAGE_DIR, f))]
+    """Sends a list of available files to the client, ignoring unwanted files."""
+    files = [
+        f for f in os.listdir(FILE_STORAGE_DIR)
+        if os.path.isfile(os.path.join(FILE_STORAGE_DIR, f)) and not should_ignore(f)
+    ]
     await websocket.send(json.dumps({"files": files}))
     logging.info("Sent file list to client.")
 
+
+# ----------------------- Watchdog and Server Setup -----------------------
+
+class AsyncSyncEventHandler(FileSystemEventHandler):
+    """
+    Monitors file system changes and debounces events before notifying clients.
+    If multiple events for the same file occur within a short interval, only the last event is processed.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, debounce_interval: float = 0.3):
+        super().__init__()
+        self.loop = loop
+        self.debounce_interval = debounce_interval
+        self.debounce_tasks: dict[str, asyncio.Task] = {}
+        self.latest_events: dict[str, str] = {}
+
+    def enqueue_event(self, event_type: str, filename: str) -> None:
+        if should_ignore(filename):
+            return
+        logging.info(f"[WATCHDOG] File {event_type}: {filename}")
+        self.latest_events[filename] = event_type
+
+        if filename in self.debounce_tasks:
+            self.debounce_tasks[filename].cancel()
+
+        self.debounce_tasks[filename] = self.loop.create_task(self._debounced_notify(filename))
+
+    async def _debounced_notify(self, filename: str) -> None:
+        try:
+            await asyncio.sleep(self.debounce_interval)
+            event_type = self.latest_events.get(filename)
+            self.latest_events.pop(filename, None)
+            self.debounce_tasks.pop(filename, None) # Dont await this
+            await notify_clients(event_type, filename)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logging.error(f"Error in debounced notify for '{filename}': {e}", exc_info=True)
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self.enqueue_event("created", os.path.basename(event.src_path))
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self.enqueue_event("modified", os.path.basename(event.src_path))
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self.enqueue_event("deleted", os.path.basename(event.src_path))
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self.enqueue_event("deleted", os.path.basename(event.src_path))
+            self.enqueue_event("created", os.path.basename(event.dest_path))
+
+
+def should_ignore(filename):
+    """Checks if the file should be ignored based on its suffixes or extension."""
+    return filename.startswith(IGNORED_PREFIXES) or filename.endswith(IGNORED_SUFFIXES)
 
 async def start_websocket_server():
     """Starts the WebSocket server."""
@@ -291,12 +359,12 @@ def start_watchdog_observer(loop):
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
-    # Start the watchdog observer using our debounced event handler.
     observer = start_watchdog_observer(loop)
+
 
     async def main():
         await start_websocket_server()
+
 
     try:
         loop.run_until_complete(main())


### PR DESCRIPTION
**FE7. De server en clients moeten onderbrekingen in de verbinding kunnen detecteren en herstellen zonder corrupte of onvolledige bestanden achter te laten. (Timer inbouwen die .part bestanden 1x in de zoveel tijd opruimt)**
_De eis komt voort uit de behoefte om te voorkomen dat er gedeeltelijke of corrupte bestanden achterblijven wanneer een upload mislukt of abrupt wordt geannuleerd en later niet wordt hervat._

Deze implementatie bereid het hervatten van upload voor, dit is een nog te implementeren functionaliteit.

Een partial is pas geschikt voor verwijdering wanneer deze niet in gebruik is en wanneer deze niet meer is aangepast na een bepaalde tijd.(huidig staat deze tijd op 10 minuten, eenvoudig aan te passen door verandering van variabel)

**Toevoegingen**
- import time om in de zoveel tijd de zaak op te schonen
- clean stale partial files functionaliteit om oude files te deleten
- start stale files clean up, instantieren van clean stale partial files in een eigen thread(tijden runtime up houden om periodiek te kunnen checken)
- aanroepen, van start stale files clean up, bij server opstart

**Aandachtspunten:**
- niet uitgebreid getest, simpele tests lijken te werken, zie eerdere PR van FE7
- Voor een correcte werking mag .partial geen geaccepteerde file extensie zijn voor een gefinaliseerde upload

**Mogelijke uitbreiding:**
- tijdelijke files buiten de gesyncte mappen bewaren.
- Wanneer een tijdelijke file/upload compleet is van de tijdelijek map naar de productie/sync map verplaatsen.
- Het scheiden van logica voor alle functionaliteit zou het makkelijker maken om verder te implementeren.
- Doormiddel van hashing zouden andere randzaken afgevangen moeten worden, er zal nog wel gekeken moeten worden hoe een upload hervat kan worden in combinatie met hashing.

**Bij het testen zijn de volgende zaken naar voor gekomen die voornamelijk buiten de scope van de FE vallen:**
- Naamswijziging niet gesynct: Bij een naamswijziging op de client wordt deze wijziging niet gesynchroniseerd met de server.
- Waarom alleen hashbestand op server? De reden dat er alleen een hashbestand op de server staat, is nog onduidelijk.
- Sync bij afgebroken verbinding: Wanneer een verbinding afbreekt, wordt de synchronisatie niet hersteld, hoewel de notificationstream opnieuw online komt wanneer de verbinding hersteld is.
- Onbegrijpelijk errorbericht: De foutmelding over bestandsoverdracht is onduidelijk, maar de bestanden lijken wel correct gesynchroniseerd.
- Time-out error: Na ontvangst van een bestand treedt er een time-out error op, maar de bestanden lijken correct te zijn gesynchroniseerd.
- Er lijkt een delete plaats te vinden na het uploaden van een bestand in combinatie met de hashing.
- Hash alleen bij succesvolle upload: De hash wordt alleen aangemaakt wanneer een upload succesvol is.
- Hash mismatch bij grote bestanden: Er komt een hash mismatch bij grote bestandssynchronisaties.